### PR TITLE
Timestamp

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,3 +38,23 @@ cd docs
 make html
 
 ```  
+
+## Adding new data types
+
+Adding support for new data types is designed to be (relatively) painless. A workflow for adding new data type (e.g. 
+`VARTYPE`) includes:
+
+
+ - Modifying `Automater.__init__`
+   - Include new data type in `Automater.__init__`'s parameters (e.g. `VARTYPE_vars=list()`)
+   - Add the new variable to `self._variable_type_dict` (e.g. `self._variable_type_dict['VARTYPE_vars'] = VARTYPE`)
+ - Modifying `constants.py` to add input support
+   - Updating `default_sklearn_mapper_pipelines` to include the SKLearn transformations to perform for this data type 
+   (e.g. `'VARTYPE_vars': [LabelEncoder()]`)
+   - Creating an input nub handler function (e.g. `def input_nub_VARTYPE_handler(variable, input_dataframe)`)
+   - Adding the input nub handler to default_input_nub_type_handlers (e.g. adding 
+   `'VARTYPE_vars': input_nub_VARTYPE_handler`)
+ - Modifying `constants.py` to add output support (optional)
+   - Updating `default_suggested_losses` to include a suggested loss (e.g. `'VARTYPE_vars': losses.mean_squared_error`)
+ - Modifying `Automater.py` to add output support (optional)
+   - Updating `_create_output_nub` to create an output layer

--- a/README.md
+++ b/README.md
@@ -173,6 +173,12 @@ to reach out to me at `13herger <at> gmail <dot> com`
 
 ### Development
 
+ - Nothing right now
+
+### 1.4.0
+
+ - Adding support for timestamp data type(#60)
+
 ### 1.3.4
 
  - Adding `Manifest.in`, with including files references in `setup.py` (#54) 
@@ -185,3 +191,7 @@ to reach out to me at `13herger <at> gmail <dot> com`
 ### Earlier
 
  - Lots of things happened. Break things and move fast 
+ 
+### X.X.X
+
+ - Description (#issue_number)

--- a/keras_pandas/Automater.py
+++ b/keras_pandas/Automater.py
@@ -12,7 +12,7 @@ from keras_pandas import constants, lib
 class Automater(object):
 
     def __init__(self, numerical_vars=list(), categorical_vars=list(), boolean_vars=list(), datetime_vars=list(),
-                 text_vars=list(), non_transformed_vars=list(), response_var=None, df_out=False):
+                 text_vars=list(), timestamp_vars=list(), non_transformed_vars=list(), response_var=None, df_out=False):
 
         self.response_var = response_var
         self.fitted = False
@@ -25,6 +25,7 @@ class Automater(object):
         self._variable_type_dict['boolean_vars'] = boolean_vars
         self._variable_type_dict['datetime_vars'] = datetime_vars
         self._variable_type_dict['text_vars'] = text_vars
+        self._variable_type_dict['timestamp_vars'] = timestamp_vars
         self._variable_type_dict['non_transformed_vars'] = non_transformed_vars
         lib.check_variable_list_are_valid(self._variable_type_dict)
 

--- a/keras_pandas/PoorMansFFT.py
+++ b/keras_pandas/PoorMansFFT.py
@@ -1,0 +1,80 @@
+from keras.engine import Layer, InputSpec
+
+import keras.backend as K
+
+
+class PoorMansFFT(Layer):
+    def __init__(self, initial_frequencies=['minutely', 'hourly', 'daily', 'weekly', 'monthly', 'quarterly', 'yearly']
+                 , **kwargs):
+        # Initialize super
+        super(PoorMansFFT, self).__init__(**kwargs)
+
+        # Initialize init variables
+        self.initial_frequencies = initial_frequencies
+
+        # Convert initial frequencies to duration in seconds
+        self.initial_frequencies_seconds = self._convert_frequencies(initial_frequencies)
+
+        pass
+
+    def build(self, input_shape):
+        # Shape checking
+        self._check_input_shape(input_shape)
+        input_dim = input_shape[1]
+
+        # Create kernel(s), based on self.add_weight
+        weight = K.variable(self.initial_frequencies_seconds, name='frequency_weights')
+        self._trainable_weights.append(weight)
+        self.kernel = weight
+
+        # Create InputSpec
+        self.input_spec = InputSpec(min_ndim=2, max_ndim=2, axes={1: input_dim})
+        pass
+
+    def call(self, inputs, **kwargs):
+        # TODO Transform inputs to scaled inputs
+
+        # TODO Transform by applying sine cosine basis to scaled inputs
+
+        pass
+
+    def compute_output_shape(self, input_shape):
+        # TODO shape checking
+        pass
+
+    def get_config(self):
+        # TODO Generate config with all init variables
+        # TODO Pull super's config
+        # TODO Update layer config w/ super's config
+        pass
+
+    def _check_input_shape(self, input_shape):
+        # Check that input_shape is of correct length
+        assert len(input_shape) >= 2
+
+        # Check that input_shape only has one value (e.g. shape `(None, 1)`
+        assert input_shape[1] == 1
+
+
+    @staticmethod
+    def _convert_frequencies(initial_frequencies):
+
+        conversions = {
+            'minutely': 60,
+            'hourly': 3600,
+            'daily': 86400,
+            'weekly': 604800,
+            'monthly': 2628288,
+            'quarterly': 7883991,
+            'yearly': 31535965
+        }
+
+        # Check for unknown initial frequencies
+        for initial_frequency in initial_frequencies:
+            if initial_frequency not in conversions:
+                raise AssertionError('Unknown initial frequency: {}. Please choose from: {}'.format(initial_frequency,
+                                                                                                    conversions.keys()))
+
+        # TODO Convert initial frequencies to duration in seconds
+        initial_frequencies_seconds = list(map(lambda x: conversions[x], initial_frequencies))
+        return initial_frequencies_seconds

--- a/keras_pandas/PoorMansFFT.py
+++ b/keras_pandas/PoorMansFFT.py
@@ -5,7 +5,8 @@ import keras.backend as K
 
 
 class PoorMansFFT(Layer):
-    def __init__(self, initial_frequencies, **kwargs):
+    def __init__(self, initial_frequencies=['minutely', 'hourly', 'daily', 'weekly', 'monthly', 'quarterly', 'yearly'],
+                 **kwargs):
         # Initialize super
         super(PoorMansFFT, self).__init__(**kwargs)
 

--- a/keras_pandas/constants.py
+++ b/keras_pandas/constants.py
@@ -17,7 +17,7 @@ default_sklearn_mapper_pipelines.update({
     'categorical_vars': [LabelEncoder()],
     'boolean_vars': [LabelEncoder()],
     'text_vars': [EmbeddingVectorizer()],
-    'timestamp_vars': [EpochTransformer],
+    'timestamp_vars': [EpochTransformer()],
     'non_transformed_vars': []
 })
 
@@ -147,5 +147,3 @@ default_input_nub_type_handlers.update({
     'text_vars': input_nub_text_handler,
     'timestamp_vars': input_nub_timestamp_handler
 })
-
-

--- a/keras_pandas/constants.py
+++ b/keras_pandas/constants.py
@@ -132,10 +132,10 @@ def input_nub_text_handler(variable, input_dataframe):
 
 
 def input_nub_timestamp_handler(variable, input_dataframe):
-    input_layer = keras.Input(shape=(1,), name='input_{}'.format(variable))
 
-    pmf = PoorMansFFT()
-    x = pmf(input_layer)
+    input_layer = keras.Input(shape=(1,), name='input_{}'.format(variable))
+    x = input_layer
+    x = PoorMansFFT()(x)
 
     return input_layer, x
 

--- a/keras_pandas/constants.py
+++ b/keras_pandas/constants.py
@@ -6,9 +6,9 @@ import numpy
 from keras import losses
 from keras.layers import Embedding, Flatten, Bidirectional, LSTM
 from sklearn.preprocessing import Imputer, StandardScaler, LabelEncoder
-from sklearn_pandas import CategoricalImputer
 
-from keras_pandas.transformations import EmbeddingVectorizer
+from keras_pandas.PoorMansFFT import PoorMansFFT
+from keras_pandas.transformations import EmbeddingVectorizer, EpochTransformer
 
 default_sklearn_mapper_pipelines = defaultdict(lambda: list())
 
@@ -17,6 +17,7 @@ default_sklearn_mapper_pipelines.update({
     'categorical_vars': [LabelEncoder()],
     'boolean_vars': [LabelEncoder()],
     'text_vars': [EmbeddingVectorizer()],
+    'timestamp_vars': [EpochTransformer],
     'non_transformed_vars': []
 })
 
@@ -130,10 +131,21 @@ def input_nub_text_handler(variable, input_dataframe):
     return input_layer, x
 
 
+def input_nub_timestamp_handler(variable, input_dataframe):
+    input_layer = keras.Input(shape=(1,), name='input_{}'.format(variable))
+
+    pmf = PoorMansFFT()
+    x = pmf(input_layer)
+
+    return input_layer, x
+
 default_input_nub_type_handlers = dict()
 
 default_input_nub_type_handlers.update({
     'numerical_vars': input_nub_numeric_handler,
     'categorical_vars': input_nub_categorical_handler,
-    'text_vars': input_nub_text_handler
+    'text_vars': input_nub_text_handler,
+    'timestamp_vars': input_nub_timestamp_handler
 })
+
+

--- a/keras_pandas/transformations.py
+++ b/keras_pandas/transformations.py
@@ -170,7 +170,6 @@ class EpochTransformer(TransformerMixin, BaseEstimator):
         observations = list(map(lambda x: numpy.array(x), observations))
         return numpy.matrix(observations)
 
-
     @staticmethod
     def prepare_input(X):
         # Undo Numpy formatting

--- a/keras_pandas/transformations.py
+++ b/keras_pandas/transformations.py
@@ -161,14 +161,14 @@ class EpochTransformer(TransformerMixin, BaseEstimator):
         observations = self.prepare_input(X)
 
         # Convert to Pandas timestamp
-        observations = pandas.to_datetime(observations)
+        observations = pandas.to_datetime(observations, errors='coerce')
 
         # Convert to seconds since epoch
         observations = observations.astype(numpy.int64)
 
         # Redo numpy formatting
-        observations = list(map(lambda x: numpy.array([x]), observations))
-        return observations
+        observations = list(map(lambda x: numpy.array(x), observations))
+        return numpy.matrix(observations)
 
 
     @staticmethod

--- a/keras_pandas/transformations.py
+++ b/keras_pandas/transformations.py
@@ -2,6 +2,7 @@ import logging
 from collections import defaultdict
 
 import numpy
+import pandas
 from gensim.utils import simple_preprocess
 from sklearn.base import BaseEstimator, TransformerMixin
 
@@ -145,5 +146,35 @@ class EmbeddingVectorizer(TransformerMixin, BaseEstimator):
         # Undo Numpy formatting
         observations = list(map(lambda x: x[0], X))
 
-        observations = map(str, observations)
+        observations = list(map(str, observations))
+        return observations
+
+class EpochTransformer(TransformerMixin, BaseEstimator):
+
+    def __init__(self):
+        pass
+
+    def fit(self, X, y=None):
+        return self
+
+    def transform(self, X):
+        observations = self.prepare_input(X)
+
+        # Convert to Pandas timestamp
+        observations = pandas.to_datetime(observations)
+
+        # Convert to seconds since epoch
+        observations = observations.astype(numpy.int64)
+
+        # Redo numpy formatting
+        observations = list(map(lambda x: numpy.array([x]), observations))
+        return observations
+
+
+    @staticmethod
+    def prepare_input(X):
+        # Undo Numpy formatting
+        observations = list(map(lambda x: x[0], X))
+
+        observations = list(map(str, observations))
         return observations

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from collections import OrderedDict
 
 from setuptools import setup, find_packages
 
-__version__ = '1.3.4'
+__version__ = '1.4.0'
 
 # Add README as long description
 with open("README.md", "r") as fh:

--- a/tests/testautomater.py
+++ b/tests/testautomater.py
@@ -82,7 +82,7 @@ class TestAutomater(TestBase):
         auto = Automater()
         self.assertEqual({'numerical_vars': list(), 'categorical_vars': list(),
                           'boolean_vars': list(), 'datetime_vars': list(), 'text_vars': list(),
-                          'non_transformed_vars': list()}, auto._variable_type_dict, )
+                          'timestamp_vars': list(), 'non_transformed_vars': list()}, auto._variable_type_dict)
         self.assertCountEqual(list(), auto._user_provided_variables)
 
         # Common use case: Variables in each
@@ -96,6 +96,7 @@ class TestAutomater(TestBase):
         response['boolean_vars'] = list()
         response['non_transformed_vars'] = list()
         response['text_vars'] = list()
+        response['timestamp_vars'] = list()
 
         auto = Automater(numerical_vars=data['numerical_vars'], categorical_vars=data['categorical_vars'],
                          datetime_vars=data['datetime_vars'])

--- a/tests/testepochtransformer.py
+++ b/tests/testepochtransformer.py
@@ -21,7 +21,7 @@ class TestEpochTransformer(TestBase):
 
         data = [['2018-09-12'], ['1970-01-01'], ['1776-07-04']]
         transformed = et.fit_transform(data)
-
-        self.assertEqual(0, transformed[1][0])
-        self.assertEqual(1536710400000000000, transformed[0][0])
-        self.assertEqual(3, len(transformed))
+        
+        self.assertEqual(0, transformed[0, 1])
+        self.assertEqual(1536710400000000000, transformed[0, 0])
+        self.assertEqual((1, 3), transformed.shape)

--- a/tests/testepochtransformer.py
+++ b/tests/testepochtransformer.py
@@ -1,0 +1,27 @@
+from keras_pandas.transformations import EpochTransformer
+from tests.testbase import TestBase
+
+
+class TestEpochTransformer(TestBase):
+
+    def test_init(self):
+        et = EpochTransformer()
+        pass
+
+    def test_fit(self):
+        et = EpochTransformer()
+
+        data = [['2018-09-12'], ['1970-01-01', '1776-07-04']]
+        et = et.fit(data)
+        self.assertEqual(EpochTransformer, type(et))
+        pass
+
+    def test_transform(self):
+        et = EpochTransformer()
+
+        data = [['2018-09-12'], ['1970-01-01'], ['1776-07-04']]
+        transformed = et.fit_transform(data)
+
+        self.assertEqual(0, transformed[1][0])
+        self.assertEqual(1536710400000000000, transformed[0][0])
+        self.assertEqual(3, len(transformed))

--- a/tests/testtext.py
+++ b/tests/testtext.py
@@ -1,9 +1,8 @@
 import logging
-import unittest
 
 import numpy
 import pandas
-from keras import losses, Model
+from keras import Model
 from keras.layers import Dense
 
 from keras_pandas import lib

--- a/tests/testtimestamp.py
+++ b/tests/testtimestamp.py
@@ -1,6 +1,6 @@
 import logging
 
-from build.lib.keras_pandas.Automater import Automater
+from keras_pandas.Automater import Automater
 from keras_pandas import lib
 from tests.testbase import TestBase
 

--- a/tests/testtimestamp.py
+++ b/tests/testtimestamp.py
@@ -1,0 +1,27 @@
+import logging
+
+from build.lib.keras_pandas.Automater import Automater
+from keras_pandas import lib
+from tests.testbase import TestBase
+
+logging.getLogger().setLevel(logging.INFO)
+
+class TestText(TestBase):
+
+    def test_create_input_nub(self):
+        data = lib.load_lending_club()
+
+        timestamp_vars = ['issue_d']
+
+        auto = Automater(timestamp_vars=timestamp_vars)
+        auto.fit(data)
+
+    def test_fit(self):
+        pass
+
+    def test_transform(self):
+        pass
+
+    def test_whole(self):
+        pass
+


### PR DESCRIPTION
Support for `timestamp_vars` data type, from #60 . 

 - Including new `input_nub_timestamp_handler`
 - Including new `PoorMansFFT` keras layer (custom written, borrowed from [timestamp_keras_layer](https://github.com/bjherger/timestamp_keras_layer))
 - Adding description for adding new layer type in `contributing.md` (Unrelated to #60 )